### PR TITLE
blender-daily-build.yaml - use gcc 14 per Blender requirement

### DIFF
--- a/.github/workflows/blender-daily-build.yaml
+++ b/.github/workflows/blender-daily-build.yaml
@@ -24,6 +24,10 @@ jobs:
         run: |
           sudo apt update
           sudo apt install python3 git git-lfs
+          # Blender is requiring gcc 14, while Ubuntu 24.04 runner has gcc 13.
+          sudo apt install gcc-14 g++-14
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 100
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 100
       - name: Install basic building environment
         run: |
           cd blender-build/blender


### PR DESCRIPTION
@nutti 

Resolves error in https://github.com/nutti/blender-daily-build/actions/runs/21423727574/job/61688257385 (`The minimum supported version of GCC is 14.0.0, found C compiler: 13.3.0`).

Example run - https://github.com/Andrej730/blender-daily-build/actions/runs/21434357308/job/61721278014

Blende requiring gcc 14 - https://developer.blender.org/docs/handbook/building_blender/#setup-for-developers